### PR TITLE
Fix newlines in the description of the query parameter

### DIFF
--- a/reference/catalogue.yaml
+++ b/reference/catalogue.yaml
@@ -183,7 +183,7 @@ paths:
             type: string
         - name: query
           in: query
-          description: 'Full-text search query, which will OR supplied terms by default.\n\nThe following special characters can be used to change the search behaviour:\n\n- \" wraps a number of tokens to signify a phrase for searching\n\nTo search for any of these special characters, they should be escaped with \.'
+          description: 'Full-text search query, which will OR supplied terms by default.<br/><br/>The following special characters can be used to change the search behaviour:<br/><br/>- \" wraps a number of tokens to signify a phrase for searching<br/><br/>To search for any of these special characters, they should be escaped with \.'
           schema:
             type: string
         - name: page


### PR DESCRIPTION
Before:

<img width="592" alt="Screenshot 2022-04-27 at 18 36 47" src="https://user-images.githubusercontent.com/301220/165586260-5388d72d-a0d1-4311-96c0-da1f88cb1f65.png">


After:

<img width="584" alt="Screenshot 2022-04-27 at 18 36 17" src="https://user-images.githubusercontent.com/301220/165586235-11584547-ca34-429c-a015-509a6db06f0d.png">
