### PR TITLE
Explain the format of dates expected by the production filters

### DIFF
--- a/reference/catalogue.yaml
+++ b/reference/catalogue.yaml
@@ -169,6 +169,7 @@ paths:
           in: query
           description: |-
             Return all works with a production date before and including this date.
+            Dates should be specified as YYYY-MM-DD, e.g. `2001-12-31` for everything created up to the end of 2001.
 
             Can be used in conjunction with `production.dates.from` to create a range.
           schema:
@@ -177,6 +178,7 @@ paths:
           in: query
           description: |-
             Return all works with a production date after and including this date.
+            Dates should be specified as YYYY-MM-DD, e.g. `1939-01-01` for everything in or after 1939.
 
             Can be used in conjunction with `production.dates.to` to create a range.
           schema:


### PR DESCRIPTION
I’m 99% sure this is correct, based on:

1. My own usage of the API
2. This test in the API repo: https://github.com/wellcomecollection/catalogue-api/blob/59ee376b7eba7bae134db97e776bae5721a1e894/search/src/test/scala/weco/api/search/works/WorksFiltersTest.scala#L167