### PR TITLE
Document the content API

### DIFF
--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -12,6 +12,9 @@ import ApiDocCard from '@site/src/components/ApiDocCard'
   <div class="col col--6">
     <ApiDocCard href="/api/iiif" title="IIIF APIs" description="Access digitised items using standard IIIF APIs." />
   </div>
+  <div class="col col--6">
+    <ApiDocCard href="/api/content" title="Content API" description="Search our editorial content." />
+  </div>
 {/* Hidden pending improved docs */}
 {/*   <div class="col col--6"> */}
 {/*     <ApiDocCard href="/api/text" title="Text API" description="Download the contents of digitised printed books." /> */}

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -13,7 +13,7 @@ import ApiDocCard from '@site/src/components/ApiDocCard'
     <ApiDocCard href="/api/iiif" title="IIIF APIs" description="Access digitised items using standard IIIF APIs." />
   </div>
   <div class="col col--6">
-    <ApiDocCard href="/api/content" title="Content API" description="Search our editorial content." />
+    <ApiDocCard href="/api/content" title="Content API" description="Search our non-catalogue content." />
   </div>
 {/* Hidden pending improved docs */}
 {/*   <div class="col col--6"> */}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -25,12 +25,12 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          remarkPlugins: [require("mdx-mermaid")],
+          remarkPlugins: [require("mdx-mermaid")]
         },
         theme: {
-          customCss: require.resolve("./src/css/custom.css"),
-        },
-      }),
+          customCss: require.resolve("./src/css/custom.css")
+        }
+      })
     ],
     [
       "redocusaurus",
@@ -39,25 +39,30 @@ const config = {
           {
             route: "api/catalogue",
             spec: "reference/catalogue.yaml",
-            layout: { title: "Catalogue API" },
+            layout: { title: "Catalogue API" }
           },
           {
             route: "api/iiif",
             spec: "reference/iiif.yaml",
-            layout: { title: "IIIF APIs" },
+            layout: { title: "IIIF APIs" }
+          },
+          {
+            route: "api/content",
+            spec: "reference/content.yaml",
+            layout: { title: "Content API" }
           },
           // This is currently disabled until the documentation can be improved
           {
             route: "api/text",
             spec: "reference/text.yaml",
-            layout: { title: "Text API" },
-          },
+            layout: { title: "Text API" }
+          }
         ],
         theme: {
-          primaryColor: "#007868",
-        },
-      },
-    ],
+          primaryColor: "#007868"
+        }
+      }
+    ]
   ],
 
   themeConfig:
@@ -70,7 +75,7 @@ const config = {
         logo: {
           alt: "Wellcome Collection",
           src: "images/wellcome-collection-black.svg",
-          srcDark: "images/wellcome-collection-white.svg",
+          srcDark: "images/wellcome-collection-white.svg"
         },
         items: [
           {
@@ -81,25 +86,29 @@ const config = {
             items: [
               {
                 to: "api/catalogue",
-                label: "Catalogue",
+                label: "Catalogue"
               },
               {
                 to: "api/iiif",
-                label: "IIIF",
+                label: "IIIF"
               },
+              {
+                to: "api/content",
+                label: "Content"
+              }
               // Hidden pending improved docs
               // {
               //   to: "api/text",
               //   label: "Text",
               // },
-            ],
+            ]
           },
           {
             href: "https://github.com/wellcomecollection",
             position: "right",
-            label: "GitHub",
-          },
-        ],
+            label: "GitHub"
+          }
+        ]
       },
       footer: {
         style: "dark",
@@ -109,71 +118,71 @@ const config = {
             items: [
               {
                 label: "API Reference",
-                to: "docs/api",
-              },
-            ],
+                to: "docs/api"
+              }
+            ]
           },
           {
             title: "Get Involved",
             items: [
               {
                 label: "Stacks",
-                href: "https://stacks.wellcomecollection.org",
+                href: "https://stacks.wellcomecollection.org"
               },
               {
                 label: "Roadmap",
-                href: "https://roadmap.wellcomecollection.org",
+                href: "https://roadmap.wellcomecollection.org"
               },
               {
                 label: "GitHub",
-                href: "https://github.com/wellcomecollection",
-              },
-            ],
+                href: "https://github.com/wellcomecollection"
+              }
+            ]
           },
           {
             title: "Contact Us",
             items: [
               {
                 label: "Twitter",
-                href: "https://twitter.com/ExploreWellcome",
+                href: "https://twitter.com/ExploreWellcome"
               },
               {
                 label: "Facebook",
-                href: "https://www.facebook.com/wellcomecollection",
+                href: "https://www.facebook.com/wellcomecollection"
               },
               {
                 label: "Email",
-                href: "mailto:digital@wellcomecollection.org",
-              },
-            ],
+                href: "mailto:digital@wellcomecollection.org"
+              }
+            ]
           },
           {
             title: "More",
             items: [
               {
                 label: "Jobs",
-                href: "https://wellcome.ac.uk/jobs",
+                href: "https://wellcome.ac.uk/jobs"
               },
               {
                 label: "Privacy",
-                href: "https://wellcome.org/who-we-are/privacy-and-terms",
+                href: "https://wellcome.org/who-we-are/privacy-and-terms"
               },
               {
                 label: "Wellcome Collection",
-                href: "https://wellcomecollection.org",
-              },
-            ],
-          },
+                href: "https://wellcomecollection.org"
+              }
+            ]
+          }
         ],
-        copyright: `Except where otherwise noted, content on this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International Licence</a>.`,
+        copyright: `Except where otherwise noted, content on this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International Licence</a>.`
       },
       prism: {
         theme: lightCodeTheme,
-        darkTheme: darkCodeTheme,
-      },
+        darkTheme: darkCodeTheme
+      }
     }),
 
-  plugins: [],
+  plugins: []
 };
 
 module.exports = config;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -161,7 +161,7 @@ const config = {
             items: [
               {
                 label: "Jobs",
-                href: "https://wellcome.ac.uk/jobs"
+                href: "https://wellcome.org/jobs"
               },
               {
                 label: "Privacy",

--- a/reference/catalogue.yaml
+++ b/reference/catalogue.yaml
@@ -183,7 +183,7 @@ paths:
             type: string
         - name: query
           in: query
-          description: 'Full-text search query, which will OR supplied terms by default.<br/><br/>The following special characters can be used to change the search behaviour:<br/><br/>- \" wraps a number of tokens to signify a phrase for searching<br/><br/>To search for any of these special characters, they should be escaped with \.'
+          description: 'Full-text search query'
           schema:
             type: string
         - name: page

--- a/reference/content.yaml
+++ b/reference/content.yaml
@@ -30,7 +30,7 @@ paths:
             type: string
         - name: contributors.contributor
           in: query
-          description: Filter the articles by contributor agent.
+          description: Filter the articles by contributor.
         - name: sort
           in: query
           description: Which field to sort the results on

--- a/reference/content.yaml
+++ b/reference/content.yaml
@@ -1,0 +1,381 @@
+openapi: 3.1.0
+info:
+  title: Content
+  description: Search our non-catalogue content
+  version: v0
+  contact: {}
+servers:
+  - url: 'https://api.wellcomecollection.org/content/v0'
+paths:
+  /articles:
+    get:
+      tags:
+        - Articles
+      summary: /articles
+      description: Returns a paginated list of articles
+      operationId: getArticles
+      parameters:
+        - name: aggregations
+          in: query
+          description: What aggregated data in relation to the results should we return.
+          schema:
+            type: string
+            enum:
+              - format
+              - contributors.contributor
+        - name: format
+          in: query
+          description: Filter the articles by format.
+          schema:
+            type: string
+        - name: contributors.contributor
+          in: query
+          description: Filter the articles by contributor agent.
+        - name: sort
+          in: query
+          description: Which field to sort the results on
+          schema:
+            type: string
+            enum:
+              - productionDate
+              - relevance
+        - name: sortOrder
+          in: query
+          description: The order that the results should be returned in.
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+        - name: publicationDate.to
+          in: query
+          description: |-
+            Return all articles with a publication date before and including this date.
+
+            Can be used in conjunction with `publicationDate.from` to create a range.
+          schema:
+            type: string
+            format: date-time
+        - name: publicationDate.from
+          in: query
+          description: |-
+            Return all articles with a publication date after and including this date.
+
+            Can be used in conjunction with `publicationDate.to` to create a range.
+          schema:
+            type: string
+            format: date-time
+        - name: query
+          in: query
+          description: 'Full-text search query'
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: The page to return from the result list
+          schema:
+            minimum: 1
+            type: integer
+            format: int64
+            default: 1
+        - name: pageSize
+          in: query
+          description: The number of articles to return per page
+          schema:
+            maximum: 100
+            minimum: 1
+            type: integer
+            format: int64
+            default: 10
+      responses:
+        '200':
+          description: The articles
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ArticleResultList'
+        '400':
+          description: Bad Request Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        '410':
+          description: Gone Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/articles/{id}':
+    get:
+      tags:
+        - Articles
+      summary: '/articles/{id}'
+      description: Returns a single article
+      operationId: getArticle
+      parameters:
+        - name: id
+          in: path
+          description: The article to return
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The article
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Article'
+        '400':
+          description: Bad Request Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        '410':
+          description: Gone Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Error'
+components:
+  schemas:
+    Aggregation:
+      title: Aggregation
+      type: object
+      description: An aggregation over the results.
+      properties:
+        buckets:
+          type: array
+          items:
+            $ref: '#/components/schemas/AggregationBucket'
+        type:
+          type: string
+    AggregationBucket:
+      title: AggregationBucket
+      type: object
+      description: An individual bucket within an aggregation.
+      properties:
+        data:
+          discriminator:
+            propertyName: type
+          oneOf:
+            - $ref: '#/components/schemas/ContributorAgent'
+            - $ref: '#/components/schemas/ArticleFormat'
+        count:
+          type: integer
+          description: The count of how often this data occurs in this set of results.
+          format: int32
+        type:
+          type: string
+    Article:
+      title: Article
+      description: A piece of editorial content
+      type: object
+      properties:
+        id:
+          type: string
+          description: The identifier of the article
+        title:
+          type: string
+          description: The title of the article
+        publicationDate:
+          type: string
+          format: date-time
+          description: The date on which the article was published
+        contributors:
+          type: array
+          description: Relates an article to its author, editor, and any other contributors
+          items:
+            $ref: '#/components/schemas/Contributor'
+        format:
+          $ref: '#/components/schemas/ArticleFormat'
+        caption:
+          type: string
+          description: A short description of the article's content
+        image:
+          $ref: '#/components/schemas/Image'
+        type:
+          type: string
+      required:
+        - id
+        - title
+        - publicationDate
+        - contributors
+        - format
+        - type
+    ArticleFormat:
+      title: ArticleFormat
+      type: object
+      description: The format of an article (eg article, comic)
+      properties:
+        id:
+          type: string
+          description: The identifier of the format
+        label:
+          type: string
+          description: The short label of the format
+        type:
+          type: string
+    Contributor:
+      title: Contributor
+      type: object
+      properties:
+        contributor:
+          $ref: '#/components/schemas/ContributorAgent'
+        role:
+          $ref: '#/components/schemas/ContributorRole'
+    ContributorRole:
+      title: ContributorRole
+      type: object
+      description: A role of a contributor (eg. author, editor)
+      properties:
+        id:
+          type: string
+          description: The identifier of the contributor role
+        label:
+          type: string
+          description: The short label of the contributor role
+        type:
+          type: string
+    ContributorAgent:
+      title: Contributor
+      type: object
+      description: A contributor
+      properties:
+        id:
+          type: string
+          description: The identifier of the contributor
+        label:
+          type: string
+          description: The name or other short label of the contributor
+        type:
+          type: enum
+          oneOf:
+            - "Person"
+            - "Organisation"
+    Dimensions:
+      type: object
+      properties:
+        width:
+          type: integer
+        height:
+          type: integer
+    Error:
+      title: Error
+      type: object
+      properties:
+        errorType:
+          type: string
+          description: The type of error
+          enum:
+            - http
+        httpStatus:
+          type: integer
+          description: The HTTP response status code
+          format: int32
+        label:
+          type: string
+          description: The title or other short name of the error
+        description:
+          type: string
+          description: The specific error
+        type:
+          type: string
+    Image:
+      title: Image
+      description: Information regarding the location, dimensions, alt-text, and copyright of an image
+      type: object
+      properties:
+        dimensions:
+          description: The intrinsic dimensions of an image
+          $ref: '#/components/schemas/Dimensions'
+        alt:
+          type: string
+          description: Alternative text to display in place of the image if it cannot be rendered
+        copyright:
+          type: string
+          description: Copyright information about the image, including the copyright holder
+        url:
+          type: string
+          format: uri
+          description: The URL of the image
+        "32:15":
+          description: Dimensions of the image for 32:15 aspect ratio
+          $ref: '#/components/schemas/Dimensions'
+        "16:9":
+          description: Dimensions of the image for 16:9 aspect ratio
+          $ref: '#/components/schemas/Dimensions'
+        square:
+          description: Dimensions of the image for a square aspect ratio
+          $ref: '#/components/schemas/Dimensions'
+        type:
+          type: string
+      required:
+        - dimensions
+        - type
+        - url
+    ArticleAggregations:
+      title: ArticleAggregations
+      type: object
+      description: A map containing the requested aggregations.
+      properties:
+        format:
+          $ref: '#/components/schemas/Aggregation'
+        contributors.contributor:
+          $ref: '#/components/schemas/Aggregation'
+        type:
+          type: string
+    ArticleResultList:
+      title:  ArticleResultList
+      type: object
+      description: A paginated list of articles.
+      properties:
+        type:
+          type: string
+        pageSize:
+          type: integer
+          format: int32
+        totalPages:
+          type: integer
+          format: int32
+        totalResults:
+          type: integer
+          format: int32
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Article'
+        prevPage:
+          type: string
+        nextPage:
+          type: string
+        aggregations:
+          - $ref: '#/components/schemas/ArticleAggregations'
+tags:
+  - name: Articles


### PR DESCRIPTION
This is just some minimal (roughly the same level of detail as for the catalogue API) OpenAPI documentation for the content API; I haven't added it to the homepage because I think it would benefit from a landing page like the others have, which would need a bit more thought.

Some autoformatting has happened in irrelevant places. I also noticed that were were claiming to support quotes in the full-text search - oops!