### PR TITLE
Update 05-working-with-snapshots-of-the-api.md

### DIFF
--- a/docs/examples/05-working-with-snapshots-of-the-api.md
+++ b/docs/examples/05-working-with-snapshots-of-the-api.md
@@ -139,17 +139,25 @@ work["title"]
 
 You'll notice that the works in the snapshot include _all_ of the fields which were available in the default API response, _and_ all of the optional fields too. The snapshots include the complete set of information we have about our works, and are a great way to get a complete picture of the collection.
 
-## Wrapping up
-
-Let's delete the snapshot we've downloaded, and wrap up all of the logic we've established so far into a single cell which we can copy and reuse in later notebooks.
-
 
 ```python
 unzipped_path.unlink()
 ```
 
 
+## Wrapping up
+
+Let's delete the snapshot we've downloaded, and wrap up all of the logic we've established so far into a single cell which we can copy and reuse in later notebooks.
+
+
 ```python
+import requests
+import json
+from pathlib import Path
+from tqdm.auto import tqdm
+import gzip
+import io
+
 snapshot_url = "https://data.wellcomecollection.org/catalogue/v2/works.json.gz"
 
 data_dir = Path("./data").resolve()
@@ -187,6 +195,12 @@ if not unzipped_path.exists():
     
         unzip_progress_bar.close()
     zipped_path.unlink()
+```
+
+We can check the location of the unzipped file.
+
+```python
+print(unzipped_path)
 ```
 
 ## Exercises

--- a/docs/examples/05-working-with-snapshots-of-the-api.md
+++ b/docs/examples/05-working-with-snapshots-of-the-api.md
@@ -139,17 +139,23 @@ work["title"]
 
 You'll notice that the works in the snapshot include _all_ of the fields which were available in the default API response, _and_ all of the optional fields too. The snapshots include the complete set of information we have about our works, and are a great way to get a complete picture of the collection.
 
+
+```python
+unzipped_path.unlink(missing_ok=True)
+```
+
 ## Wrapping up
 
 Let's delete the snapshot we've downloaded, and wrap up all of the logic we've established so far into a single cell which we can copy and reuse in later notebooks.
 
 
 ```python
-unzipped_path.unlink()
-```
+import requests
+from pathlib import Path
+from tqdm.auto import tqdm
+import gzip
+import io
 
-
-```python
 snapshot_url = "https://data.wellcomecollection.org/catalogue/v2/works.json.gz"
 
 data_dir = Path("./data").resolve()
@@ -187,6 +193,13 @@ if not unzipped_path.exists():
     
         unzip_progress_bar.close()
     zipped_path.unlink()
+```
+
+We can check the location of the unzipped file.
+
+
+```python
+print(unzipped_path)
 ```
 
 ## Exercises

--- a/docs/examples/05-working-with-snapshots-of-the-api.md
+++ b/docs/examples/05-working-with-snapshots-of-the-api.md
@@ -139,25 +139,17 @@ work["title"]
 
 You'll notice that the works in the snapshot include _all_ of the fields which were available in the default API response, _and_ all of the optional fields too. The snapshots include the complete set of information we have about our works, and are a great way to get a complete picture of the collection.
 
-
-```python
-unzipped_path.unlink()
-```
-
-
 ## Wrapping up
 
 Let's delete the snapshot we've downloaded, and wrap up all of the logic we've established so far into a single cell which we can copy and reuse in later notebooks.
 
 
 ```python
-import requests
-import json
-from pathlib import Path
-from tqdm.auto import tqdm
-import gzip
-import io
+unzipped_path.unlink()
+```
 
+
+```python
 snapshot_url = "https://data.wellcomecollection.org/catalogue/v2/works.json.gz"
 
 data_dir = Path("./data").resolve()
@@ -195,12 +187,6 @@ if not unzipped_path.exists():
     
         unzip_progress_bar.close()
     zipped_path.unlink()
-```
-
-We can check the location of the unzipped file.
-
-```python
-print(unzipped_path)
 ```
 
 ## Exercises

--- a/notebooks/05-working-with-snapshots-of-the-api.ipynb
+++ b/notebooks/05-working-with-snapshots-of-the-api.ipynb
@@ -219,8 +219,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You'll notice that the works in the snapshot include _all_ of the fields which were available in the default API response, _and_ all of the optional fields too. The snapshots include the complete set of information we have about our works, and are a great way to get a complete picture of the collection.\n",
-    "\n",
+    "You'll notice that the works in the snapshot include _all_ of the fields which were available in the default API response, _and_ all of the optional fields too. The snapshots include the complete set of information we have about our works, and are a great way to get a complete picture of the collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "unzipped_path.unlink(missing_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Wrapping up\n",
     "\n",
     "Let's delete the snapshot we've downloaded, and wrap up all of the logic we've established so far into a single cell which we can copy and reuse in later notebooks."
@@ -232,15 +246,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unzipped_path.unlink()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import requests\n",
+    "from pathlib import Path\n",
+    "from tqdm.auto import tqdm\n",
+    "import gzip\n",
+    "import io\n",
+    "\n",
     "snapshot_url = \"https://data.wellcomecollection.org/catalogue/v2/works.json.gz\"\n",
     "\n",
     "data_dir = Path(\"./data\").resolve()\n",
@@ -278,6 +289,22 @@
     "    \n",
     "        unzip_progress_bar.close()\n",
     "    zipped_path.unlink()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can check the location of the unzipped file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(unzipped_path)"
    ]
   },
   {


### PR DESCRIPTION
"unzipped_path.unlink()" interferes with the code in Wrapping up which users should be able to run from scratch.