### PR TITLE
Remove dead roadmap link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,10 +130,6 @@ const config = {
                 href: "https://stacks.wellcomecollection.org"
               },
               {
-                label: "Roadmap",
-                href: "https://roadmap.wellcomecollection.org"
-              },
-              {
                 label: "GitHub",
                 href: "https://github.com/wellcomecollection"
               }


### PR DESCRIPTION
## What does this change?

Removes dead roadmap link ([see Slack thread](https://wellcome.slack.com/archives/C3TQSF63C/p1704980806814589))
Relates to #26 

## How to test

run it locally and look at the footer's Get Involved section, it should've been removed

## How can we measure success?

No dead links no more

## Have we considered potential risks?

It's my first time deploying this particular repo, so might have some hiccups, but the change itself is fairly simple.