### PR TITLE
Delete .buildkite directory

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,0 @@
-steps:
-  - command: true
-    label: "Take no action"

--- a/docs/examples/01-exploring-wellcome-collections-apis.md
+++ b/docs/examples/01-exploring-wellcome-collections-apis.md
@@ -1,6 +1,6 @@
 # 1. Exploring Wellcome Collection's APIs
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/01-exploring-wellcome-collections-apis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/01-exploring-wellcome-collections-apis.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/01-exploring-wellcome-collections-apis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/01-exploring-wellcome-collections-apis.ipynb)
 
 Wellcome collection has a few public APIs which can be used to fetch things like works, images, and concepts. They all live behind the following base URL
 

--- a/docs/examples/02-extracting-more-data-for-local-analysis.md
+++ b/docs/examples/02-extracting-more-data-for-local-analysis.md
@@ -1,6 +1,6 @@
 # 2. Extracting more data for local analysis
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/02-extracting-more-data-for-local-analysis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/02-extracting-more-data-for-local-analysis.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/02-extracting-more-data-for-local-analysis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/02-extracting-more-data-for-local-analysis.ipynb)
 
 In the last notebook, we saw that the `/works` API can do some clever querying and filtering. However, we often have questions which can't be answered by the API by itself. In those cases, it's useful to collect a load of data from the API and then analyse it locally.
 

--- a/docs/examples/03-connecting-the-apis-together.md
+++ b/docs/examples/03-connecting-the-apis-together.md
@@ -1,6 +1,6 @@
 # 3. Connecting the APIs together
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/03-connecting-the-apis-together.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/03-connecting-the-apis-together.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/03-connecting-the-apis-together.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/03-connecting-the-apis-together.ipynb)
 
 So far, we've only looked at the `/works` API, but Wellcome Collection has a few more which we can make use of. As well as `/works`, we can also use `/images` and `/concepts`. 
 

--- a/docs/examples/04-building-graphs-of-visually-similar-images.md
+++ b/docs/examples/04-building-graphs-of-visually-similar-images.md
@@ -1,6 +1,6 @@
 # 4. Building graphs of visually similar images
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/04-building-graphs-of-visually-similar-images.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/04-building-graphs-of-visually-similar-images.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/04-building-graphs-of-visually-similar-images.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/04-building-graphs-of-visually-similar-images.ipynb)
 
 In the last notebook, we introduced the ability to fetch visually similar images using the `/images` API.
 

--- a/docs/examples/05-working-with-snapshots-of-the-api.md
+++ b/docs/examples/05-working-with-snapshots-of-the-api.md
@@ -1,6 +1,6 @@
 # 5. Working with snapshots of the API
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/05-working-with-snapshots-of-the-api.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/05-working-with-snapshots-of-the-api.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/05-working-with-snapshots-of-the-api.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/05-working-with-snapshots-of-the-api.ipynb)
 
 As we saw at the end of the last notebook, the API limits its responses to 10,000 total results - after that point, users are directed to work with the snapshots. For example, making a request to <https://api.wellcomecollection.org/catalogue/v2/works?pageSize=100&page=101> gives us:
 

--- a/docs/examples/06-visualising-the-collection-on-a-map.md
+++ b/docs/examples/06-visualising-the-collection-on-a-map.md
@@ -1,6 +1,6 @@
 # 6. Visualising the collections on a map
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/06-visualising-the-collection-on-a-map.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/06-visualising-the-collection-on-a-map.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/06-visualising-the-collection-on-a-map.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/06-visualising-the-collection-on-a-map.ipynb)
 
 In this notebook, we're going to use a secondary API to visualise the geographical extent of the collection on a map. 
 

--- a/docs/examples/07-building-an-image-classifier.md
+++ b/docs/examples/07-building-an-image-classifier.md
@@ -1,6 +1,6 @@
 # 7. Building an image classifier
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/07-building-an-image-classifier.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/07-building-an-image-classifier.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/07-building-an-image-classifier.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/07-building-an-image-classifier.ipynb)
 
 This notebook is going to race through some high-level concepts in machine learning (specifically, fine-tuning a convolutional neural network). However, our focus will remain on demonstrating the practical uses of the Wellcome Collection API. As such, some important ML topics will be covered in less detail than they deserve, and some will be skipped entirely.
 If you're not already familiar with the basics of ML but want to learn more, I'd recommend exploring [Practical Deep Learning for Coders](https://course.fast.ai/) by fast.ai. It describes itself as:

--- a/docs/examples/08-extracting-features-from-text.md
+++ b/docs/examples/08-extracting-features-from-text.md
@@ -1,6 +1,6 @@
 # 8. Extracting features from text
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/08-extracting-features-from-text.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/08-extracting-features-from-text.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/08-extracting-features-from-text.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/08-extracting-features-from-text.ipynb)
 
 In the last notebook, we saw that using a pre-trained network allowed us to extract features from images, and train a classifier for new categories on top of those features. We can do the same thing with text, using a pre-trained network to extract features from text. In this notebook, we'll use those features the visualise the similarities and differences between works in the collection, and try to find clusters of related material.
 

--- a/docs/examples/09-building-a-recommender-system-for-subjects.md
+++ b/docs/examples/09-building-a-recommender-system-for-subjects.md
@@ -1,6 +1,6 @@
 # 9. Building a recommender system for subjects
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/09-building-a-recommender-system-for-subjects.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/09-building-a-recommender-system-for-subjects.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/09-building-a-recommender-system-for-subjects.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/rk/remove-buildkite-pipeline/notebooks/09-building-a-recommender-system-for-subjects.ipynb)
 
 Finally, we'll consider building a recommender system using data from Wellcome Collection. Thes machine learning models work slightly differently to the ones we've seen so far. Rather than being trained to predict a single value, they're trained to predict a whole matrix of interactions between two kinds of entity.
 


### PR DESCRIPTION
## What does this change?

Following https://github.com/wellcomecollection/developers.wellcomecollection.org/pull/28 removes the Buildkite YAML.

See also: https://github.com/wellcomecollection/buildkite-infrastructure/pull/25

## How to test

- [x] Has the buildkite build been removed? Are no buildkite checks run on PRs?

## How can we measure success?

Less code.

## Have we considered potential risks?

As long as the Buildkite build has been destroyed the risk is minimal.
