### PR TITLE
Updates GitHub Actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
         contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Convert Notebooks
@@ -27,7 +27,7 @@ jobs:
     # https://github.com/actions/setup-node?tab=readme-ov-file#usage
     # The node-version input is optional. If not supplied, the node version from PATH will be used.
     # However, it is recommended to always specify Node.js version and don't rely on the system one.
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
     - name: Build website
       run: yarn build
     - name: Upload Build Artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: build
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Convert Notebooks
@@ -27,7 +27,7 @@ jobs:
     # https://github.com/actions/setup-node?tab=readme-ov-file#usage
     # The node-version input is optional. If not supplied, the node version from PATH will be used.
     # However, it is recommended to always specify Node.js version and don't rely on the system one.
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
     - name: Install dependencies

--- a/docs/examples/01-exploring-wellcome-collections-apis.md
+++ b/docs/examples/01-exploring-wellcome-collections-apis.md
@@ -1,6 +1,6 @@
 # 1. Exploring Wellcome Collection's APIs
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/01-exploring-wellcome-collections-apis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/01-exploring-wellcome-collections-apis.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/01-exploring-wellcome-collections-apis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/01-exploring-wellcome-collections-apis.ipynb)
 
 Wellcome collection has a few public APIs which can be used to fetch things like works, images, and concepts. They all live behind the following base URL
 

--- a/docs/examples/02-extracting-more-data-for-local-analysis.md
+++ b/docs/examples/02-extracting-more-data-for-local-analysis.md
@@ -1,6 +1,6 @@
 # 2. Extracting more data for local analysis
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/02-extracting-more-data-for-local-analysis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/02-extracting-more-data-for-local-analysis.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/02-extracting-more-data-for-local-analysis.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/02-extracting-more-data-for-local-analysis.ipynb)
 
 In the last notebook, we saw that the `/works` API can do some clever querying and filtering. However, we often have questions which can't be answered by the API by itself. In those cases, it's useful to collect a load of data from the API and then analyse it locally.
 

--- a/docs/examples/03-connecting-the-apis-together.md
+++ b/docs/examples/03-connecting-the-apis-together.md
@@ -1,6 +1,6 @@
 # 3. Connecting the APIs together
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/03-connecting-the-apis-together.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/03-connecting-the-apis-together.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/03-connecting-the-apis-together.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/03-connecting-the-apis-together.ipynb)
 
 So far, we've only looked at the `/works` API, but Wellcome Collection has a few more which we can make use of. As well as `/works`, we can also use `/images` and `/concepts`. 
 

--- a/docs/examples/04-building-graphs-of-visually-similar-images.md
+++ b/docs/examples/04-building-graphs-of-visually-similar-images.md
@@ -1,6 +1,6 @@
 # 4. Building graphs of visually similar images
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/04-building-graphs-of-visually-similar-images.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/04-building-graphs-of-visually-similar-images.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/04-building-graphs-of-visually-similar-images.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/04-building-graphs-of-visually-similar-images.ipynb)
 
 In the last notebook, we introduced the ability to fetch visually similar images using the `/images` API.
 

--- a/docs/examples/05-working-with-snapshots-of-the-api.md
+++ b/docs/examples/05-working-with-snapshots-of-the-api.md
@@ -1,6 +1,6 @@
 # 5. Working with snapshots of the API
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/05-working-with-snapshots-of-the-api.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/05-working-with-snapshots-of-the-api.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/05-working-with-snapshots-of-the-api.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/05-working-with-snapshots-of-the-api.ipynb)
 
 As we saw at the end of the last notebook, the API limits its responses to 10,000 total results - after that point, users are directed to work with the snapshots. For example, making a request to [https://api.wellcomecollection.org/catalogue/v2/works?pageSize=100&page=101](https://api.wellcomecollection.org/catalogue/v2/works?pageSize=100&page=101) gives us:
 

--- a/docs/examples/06-visualising-the-collection-on-a-map.md
+++ b/docs/examples/06-visualising-the-collection-on-a-map.md
@@ -1,6 +1,6 @@
 # 6. Visualising the collections on a map
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/06-visualising-the-collection-on-a-map.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/06-visualising-the-collection-on-a-map.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/06-visualising-the-collection-on-a-map.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/06-visualising-the-collection-on-a-map.ipynb)
 
 In this notebook, we're going to use a secondary API to visualise the geographical extent of the collection on a map. 
 

--- a/docs/examples/07-building-an-image-classifier.md
+++ b/docs/examples/07-building-an-image-classifier.md
@@ -1,6 +1,6 @@
 # 7. Building an image classifier
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/07-building-an-image-classifier.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/07-building-an-image-classifier.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/07-building-an-image-classifier.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/07-building-an-image-classifier.ipynb)
 
 This notebook is going to race through some high-level concepts in machine learning (specifically, fine-tuning a convolutional neural network). However, our focus will remain on demonstrating the practical uses of the Wellcome Collection API. As such, some important ML topics will be covered in less detail than they deserve, and some will be skipped entirely.
 If you're not already familiar with the basics of ML but want to learn more, I'd recommend exploring [Practical Deep Learning for Coders](https://course.fast.ai/) by fast.ai. It describes itself as:

--- a/docs/examples/08-extracting-features-from-text.md
+++ b/docs/examples/08-extracting-features-from-text.md
@@ -1,6 +1,6 @@
 # 8. Extracting features from text
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/08-extracting-features-from-text.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/08-extracting-features-from-text.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/08-extracting-features-from-text.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/08-extracting-features-from-text.ipynb)
 
 In the last notebook, we saw that using a pre-trained network allowed us to extract features from images, and train a classifier for new categories on top of those features. We can do the same thing with text, using a pre-trained network to extract features from text. In this notebook, we'll use those features the visualise the similarities and differences between works in the collection, and try to find clusters of related material.
 

--- a/docs/examples/09-building-a-recommender-system-for-subjects.md
+++ b/docs/examples/09-building-a-recommender-system-for-subjects.md
@@ -1,6 +1,6 @@
 # 9. Building a recommender system for subjects
 
-[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/09-building-a-recommender-system-for-subjects.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/main/notebooks/09-building-a-recommender-system-for-subjects.ipynb)
+[View on GitHub](https://github.com/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/09-building-a-recommender-system-for-subjects.ipynb) | [Run in Google Colab](https://colab.research.google.com/github/wellcomecollection/developers.wellcomecollection.org/blob/update-actions/notebooks/09-building-a-recommender-system-for-subjects.ipynb)
 
 Finally, we'll consider building a recommender system using data from Wellcome Collection. Thes machine learning models work slightly differently to the ones we've seen so far. Rather than being trained to predict a single value, they're trained to predict a whole matrix of interactions between two kinds of entity.
 


### PR DESCRIPTION
Updates GitHub Actions versions in CI workflows to address Node.js 20 deprecation warnings and align with Node.js 24-compatible action runtimes.

## Changes

- Bumped `actions/checkout` from `v4` to `v6` in:
  - `.github/workflows/deploy.yml`
  - `.github/workflows/test.yml`
- Bumped `actions/setup-node` from `v4` to `v6` in:
  - `.github/workflows/deploy.yml`
  - `.github/workflows/test.yml`
- Bumped `actions/upload-pages-artifact` from `v3` to `v5` in:
  - `.github/workflows/deploy.yml`
- Bumped `actions/deploy-pages` from `v4` to `v5` in:
  - `.github/workflows/deploy.yml`

## Why

GitHub Actions warnings indicated Node.js 20 deprecation for workflow actions. These updates move workflows to newer major versions that support the Node.js 24 transition timeline.

## Impact

- No application code changes.
- No expected functional changes to docs build/deploy behavior.
- Intended effect is removal of Node.js 20 deprecation warnings in workflow runs.

## Validation

- Verified workflow files were updated:
  - `.github/workflows/deploy.yml`
  - `.github/workflows/test.yml`
- Full validation is via GitHub Actions runs on this branch/PR.
